### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,7 +354,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.8.6'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: versions.springdocOpenApiUI
 
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '5.1.9'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
   implementation group: 'com.fasterxml.jackson', name: 'jackson-bom', version: versions.jacksonBom, ext: 'pom'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.